### PR TITLE
Fix code scanning alert no. 19: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/tools/font/otf2bdf/otf2bdf.c
+++ b/tools/font/otf2bdf/otf2bdf.c
@@ -835,7 +835,7 @@ generate_font(FILE *out, char *iname, char *oname)
         ex = ey = 0;
         bp = face->glyph->bitmap.buffer;
         for (y = 0; y < face->glyph->bitmap.rows; y++) {
-            for (x = 0; x < face->glyph->bitmap.width; x++) {
+            for (unsigned int x = 0; x < face->glyph->bitmap.width; x++) {
                 if (bp[x >> 3] & (0x80 >> (x & 7))) {
                     if (x < sx) sx = x;
                     if (x > ex) ex = x;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/u8glib/security/code-scanning/19](https://github.com/cooljeanius/u8glib/security/code-scanning/19)

To fix the problem, we need to ensure that the variable `x` is of a type that is at least as wide as `face->glyph->bitmap.width`. The best way to do this is to change the type of `x` from `FT_Short` to `unsigned int`, which matches the type of `face->glyph->bitmap.width`. This change will prevent any overflow issues and ensure the comparison is valid.

- **General Fix**: Change the type of the narrower variable to match the wider variable.
- **Detailed Fix**: Change the type of `x` from `FT_Short` to `unsigned int` in the relevant loop.
- **Specific Lines to Change**: Update the declaration of `x` in the loop on line 837.
- **Required Changes**: No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
