### PR TITLE
Fix code scanning alert no. 23: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/tools/font/otf2bdf/otf2bdf.c
+++ b/tools/font/otf2bdf/otf2bdf.c
@@ -838,7 +838,7 @@ generate_font(FILE *out, char *iname, const char *oname)
         ex = ey = 0;
         bp = global_face->glyph->bitmap.buffer;
         for (y = 0; y < global_face->glyph->bitmap.rows; y++) {
-            for (x = 0; x < global_face->glyph->bitmap.width; x++) {
+            for (unsigned int x = 0; x < global_face->glyph->bitmap.width; x++) {
                 if (bp[x >> 3] & (0x80 >> (x & 7))) {
                     if (x < sx) sx = x;
                     if (x > ex) ex = x;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/u8glib/security/code-scanning/23](https://github.com/cooljeanius/u8glib/security/code-scanning/23)

To fix the problem, we need to ensure that the variable `x` is of a type that is at least as wide as `global_face->glyph->bitmap.width`. The best way to achieve this is to change the type of `x` from `FT_Short` to `unsigned int`, which matches the type of `global_face->glyph->bitmap.width`. This change will prevent any potential overflow issues and ensure the comparison behaves as expected.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
