### PR TITLE
Fix code scanning alert no. 24: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/tools/font/otf2bdf/otf2bdf.c
+++ b/tools/font/otf2bdf/otf2bdf.c
@@ -834,6 +834,7 @@ generate_font(FILE *out, char *iname, const char *oname)
          * Determine the actual bounding box of the glyph bitmap.  Do not
          * forget that the glyph is rendered upside down!
          */
+        unsigned int y;
         sx = sy = 0xffff;
         ex = ey = 0;
         bp = global_face->glyph->bitmap.buffer;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/u8glib/security/code-scanning/24](https://github.com/cooljeanius/u8glib/security/code-scanning/24)

To fix the problem, we need to ensure that the variable `y` is of a type that can safely be compared with `global_face->glyph->bitmap.rows`. The best way to do this is to change the type of `y` from `FT_Short` to `unsigned int`, which matches the type of `global_face->glyph->bitmap.rows`. This change will prevent any overflow issues and ensure that the comparison is valid.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
