### PR TITLE
Fix code scanning alert no. 16: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/csrc/u8g_dev_ssd1351_128x128.c
+++ b/csrc/u8g_dev_ssd1351_128x128.c
@@ -665,7 +665,7 @@ uint8_t u8g_dev_ssd1351_128x128_hicolor_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t m
     case U8G_DEV_MSG_PAGE_NEXT:
       {
         u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);
-        uint8_t i, j;
+        u8g_uint_t i, j;
         uint8_t page_height;
 	uint8_t *ptr = pb->buf;
 


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/u8glib/security/code-scanning/16](https://github.com/cooljeanius/u8glib/security/code-scanning/16)

To fix the problem, we need to ensure that the variable `i` is of the same type or a wider type than `pb->width`. This can be achieved by changing the type of `i` from `uint8_t` to `u8g_uint_t`. This change will ensure that the comparison in the loop condition is between two variables of the same type, preventing any potential overflow issues.

- **General Fix:** Change the type of the narrower variable (`i`) to match the type of the wider variable (`pb->width`).
- **Detailed Fix:** Update the declaration of `i` on line 668 from `uint8_t` to `u8g_uint_t`.
- **Specific Changes:** Modify the type of `i` in the file `csrc/u8g_dev_ssd1351_128x128.c` on line 668.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
