### PR TITLE
Fix code scanning alert no. 15: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/csrc/u8g_dev_ssd1351_128x128.c
+++ b/csrc/u8g_dev_ssd1351_128x128.c
@@ -711,7 +711,7 @@ uint8_t u8g_dev_ssd1351_128x128gh_hicolor_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t
     case U8G_DEV_MSG_PAGE_NEXT:
       {
         u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);
-        uint8_t i, j;
+        u8g_uint_t i, j;
         uint8_t page_height;
 	uint8_t *ptr = pb->buf;
 


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/u8glib/security/code-scanning/15](https://github.com/cooljeanius/u8glib/security/code-scanning/15)

To fix the problem, we need to ensure that the variable `i` is of a type that is at least as wide as `u8g_uint_t`. This can be achieved by changing the type of `i` from `uint8_t` to `u8g_uint_t`. This change will ensure that the comparison between `i` and `pb->width` is safe and will not lead to unexpected behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
