### PR TITLE
Fix code scanning alert no. 13: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/csrc/u8g_dev_ssd1325_nhd27oled_gr_new.c
+++ b/csrc/u8g_dev_ssd1325_nhd27oled_gr_new.c
@@ -185,7 +185,7 @@ static uint8_t u8g_dev_ssd1325_nhd27oled_2x_gr_fn(u8g_t *u8g, u8g_dev_t *dev, ui
       break;
     case U8G_DEV_MSG_PAGE_NEXT:
       {
-	uint8_t i;
+	u8g_uint_t i;
 	u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);
 	uint8_t *p = pb->buf;
 	u8g_uint_t cnt;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/u8glib/security/code-scanning/13](https://github.com/cooljeanius/u8glib/security/code-scanning/13)

To fix the problem, we need to ensure that the variable `i` is of the same type or a wider type than `pb->p.page_height`. This can be achieved by changing the type of `i` from `uint8_t` to `u8g_uint_t`. This change ensures that the comparison in the loop condition is between two variables of the same type, preventing any potential overflow or infinite loop issues.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
