### PR TITLE
Fix code scanning alert no. 12: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/csrc/u8g_dev_ssd1325_nhd27oled_bw_new.c
+++ b/csrc/u8g_dev_ssd1325_nhd27oled_bw_new.c
@@ -140,7 +140,7 @@ static uint8_t u8g_dev_ssd1325_nhd27oled_bw_fn(u8g_t *u8g, u8g_dev_t *dev, uint8
       break;
     case U8G_DEV_MSG_PAGE_NEXT:
       {
-	uint8_t i;
+	u8g_uint_t i;
 	u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);
 	uint8_t *p = pb->buf;
 	u8g_uint_t cnt;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/u8glib/security/code-scanning/12](https://github.com/cooljeanius/u8glib/security/code-scanning/12)

To fix the problem, we need to ensure that the variable `i` is of the same type as `pb->p.page_height` to avoid any unexpected behavior due to type mismatch. The best way to fix this is to change the type of `i` from `uint8_t` to `u8g_uint_t`, which matches the type of `pb->p.page_height`.

- **General Fix:** Change the type of the narrower variable to match the wider variable in the comparison.
- **Detailed Fix:** Change the declaration of `i` from `uint8_t` to `u8g_uint_t` on line 143.
- **Specific Changes:** Modify the type of `i` in the loop condition to match `pb->p.page_height`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
