### PR TITLE
Fix code scanning alert no. 9: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/csrc/u8g_dev_ssd1322_nhd31oled_gr.c
+++ b/csrc/u8g_dev_ssd1322_nhd31oled_gr.c
@@ -281,7 +281,7 @@ uint8_t u8g_dev_ssd1322_nhd31oled_2x_gr_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t m
       break;
     case U8G_DEV_MSG_PAGE_NEXT:
       {
-	uint8_t i;
+	u8g_uint_t i;
 	u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);
 	uint8_t *p = pb->buf;
 	u8g_uint_t cnt;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/u8glib/security/code-scanning/9](https://github.com/cooljeanius/u8glib/security/code-scanning/9)

To fix the problem, we need to ensure that the variable `i` is of the same type or a wider type than `pb->p.page_height`. The best way to fix this without changing the existing functionality is to change the type of `i` from `uint8_t` to `u8g_uint_t`. This ensures that the comparison is between two variables of the same type, preventing any potential overflow or infinite loop issues.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
