### PR TITLE
Fix code scanning alert no. 8: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/csrc/u8g_dev_ssd1322_nhd31oled_bw.c
+++ b/csrc/u8g_dev_ssd1322_nhd31oled_bw.c
@@ -225,7 +225,7 @@ uint8_t u8g_dev_ssd1322_nhd31oled_bw_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg,
       break;
     case U8G_DEV_MSG_PAGE_NEXT:
       {
-	uint8_t i;
+	u8g_uint_t i;
 	u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);
 	uint8_t *p = pb->buf;
 	u8g_uint_t cnt;


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/u8glib/security/code-scanning/8](https://github.com/cooljeanius/u8glib/security/code-scanning/8)

To fix the problem, we need to ensure that the variable `i` is of the same type as `pb->p.page_height` to avoid any type mismatch issues. The best way to do this is to change the type of `i` from `uint8_t` to `u8g_uint_t`, which matches the type of `pb->p.page_height`.

- **General Fix:** Change the type of the narrower variable to match the wider variable in the comparison.
- **Detailed Fix:** In the file `csrc/u8g_dev_ssd1322_nhd31oled_bw.c`, change the declaration of `i` from `uint8_t` to `u8g_uint_t` on line 228.
- **Specific Changes:** Update the type of `i` in the loop condition to match `pb->p.page_height`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
