### PR TITLE
Fix code scanning alert no. 6: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/csrc/u8g_dev_ili9325d_320x240.c
+++ b/csrc/u8g_dev_ili9325d_320x240.c
@@ -281,7 +281,7 @@ uint8_t u8g_dev_ili9325d_320x240_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, voi
       break;
     case U8G_DEV_MSG_PAGE_NEXT:
       {
-        uint8_t i;
+        u8g_uint_t i;
         uint16_t y, j;
         uint8_t *ptr;
         u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/u8glib/security/code-scanning/6](https://github.com/cooljeanius/u8glib/security/code-scanning/6)

To fix the problem, we need to ensure that the variable `i` is of a type that is at least as wide as `u8g_uint_t`. This can be achieved by changing the type of `i` from `uint8_t` to `u8g_uint_t`. This change will ensure that the comparison between `i` and `pb->p.page_height` is valid and will not lead to unexpected behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
