### PR TITLE
Fix code scanning alert no. 5: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/csrc/u8g_dev_a2_micro_printer.c
+++ b/csrc/u8g_dev_a2_micro_printer.c
@@ -53,7 +53,8 @@ uint8_t u8g_dev_a2_micro_printer_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, voi
       break;
     case U8G_DEV_MSG_PAGE_NEXT:
       {
-        uint8_t y, i, j;
+        uint8_t y, i;
+        int j;
         uint8_t *ptr;
         u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);
         

--- a/csrc/u8g_dev_a2_micro_printer.c
+++ b/csrc/u8g_dev_a2_micro_printer.c
@@ -53,7 +53,8 @@ uint8_t u8g_dev_a2_micro_printer_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, voi
       break;
     case U8G_DEV_MSG_PAGE_NEXT:
       {
-        uint8_t y, i;
+        uint8_t y;
+	u8g_uint_t i;
         int j;
         uint8_t *ptr;
         u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/u8glib/security/code-scanning/5](https://github.com/cooljeanius/u8glib/security/code-scanning/5)

To fix the problem, we need to ensure that the variable `j` is of a type that is at least as wide as the type of `pb->width/8`. The simplest way to achieve this is to change the type of `j` from `uint8_t` to `int`. This ensures that both sides of the comparison are of the same type, preventing any unexpected behavior due to type mismatch.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
