### PR TITLE
Fix code scanning alert no. 2: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/csrc/u8g_dev_a2_micro_printer.c
+++ b/csrc/u8g_dev_a2_micro_printer.c
@@ -131,7 +131,8 @@ uint8_t u8g_dev_a2_micro_printer_double_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t m
       break;
     case U8G_DEV_MSG_PAGE_NEXT:
       {
-        uint8_t y, i;
+        uint8_t y;
+	u8g_uint_t i;
         uint16_t j;
         uint8_t *ptr;
         uint8_t *p2;

--- a/csrc/u8g_dev_a2_micro_printer.c
+++ b/csrc/u8g_dev_a2_micro_printer.c
@@ -131,7 +131,8 @@ uint8_t u8g_dev_a2_micro_printer_double_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t m
       break;
     case U8G_DEV_MSG_PAGE_NEXT:
       {
-        uint8_t y, i, j;
+        uint8_t y, i;
+        uint16_t j;
         uint8_t *ptr;
         uint8_t *p2;
         u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/u8glib/security/code-scanning/2](https://github.com/cooljeanius/u8glib/security/code-scanning/2)

To fix the problem, we need to ensure that the variable `j` is of a type that is at least as wide as the type of `pb->width/8`. The safest approach is to change the type of `j` to `uint16_t`, which can accommodate larger values and prevent any overflow issues.

- Change the type of `j` from `uint8_t` to `uint16_t`.
- This change should be made in the function `u8g_dev_a2_micro_printer_double_fn` where `j` is declared.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
