### PR TITLE
Potential fix for code scanning alert no. 26: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/tools/font/otf2bdf/otf2bdf.c
+++ b/tools/font/otf2bdf/otf2bdf.c
@@ -741,9 +741,9 @@ generate_font(FILE *out, char *iname, const char *oname)
 {
     int eof, ismono, i;
     FILE *tmp;
-    FT_Short x, y, dwidth, swidth;
+    FT_Short dwidth, swidth;
     FT_Short y_off, x_off;
-    FT_Long sx, sy, ex, ey, wd, ht;
+    FT_Long x, y, sx, sy, ex, ey, wd, ht;
     FT_Long code, idx, ng, aw;
     FT_UShort remapped_code;
     unsigned char *bp;


### PR DESCRIPTION
Potential fix for [https://github.com/cooljeanius/u8glib/security/code-scanning/26](https://github.com/cooljeanius/u8glib/security/code-scanning/26)

Use a loop index type at least as wide as the loop bound expression.  
Best fix: change `y` (and similarly `x`, since it is compared with `ex - sx` in the nested loop) from `FT_Short` to `FT_Long` in `generate_font`. This preserves behavior while removing the narrow/wide comparison risk and potential overflow in loop increments.

Edit only `tools/font/otf2bdf/otf2bdf.c`, in the local variable declarations at the start of `generate_font`:
- Keep `dwidth`, `swidth`, `y_off`, `x_off` as `FT_Short` (they are formatting/metric shorts).
- Move `x` and `y` to the existing `FT_Long` declaration list.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
